### PR TITLE
Support to add additional JWT headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var xtend = require('xtend')
+
 const crypto    = require('crypto')
 const b64url    = require('base64-url')
 const inherits  = require('util').inherits
@@ -43,7 +45,10 @@ function encode (key, payload, algorithm, cb) {
     return prcResult(validationError, null, cb)
   }
 
-  var parts = b64url.encode(JSON.stringify({typ: 'JWT', alg: algorithm})) +
+  var header = xtend({typ: 'JWT', alg: algorithm}, payload.header);
+  delete payload.header;
+
+  var parts = b64url.encode(JSON.stringify(header)) +
     '.' +
     b64url.encode(JSON.stringify(payload))
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "homepage": "https://github.com/joaquimserafim/json-web-token",
   "dependencies": {
     "base64-url": "^1.2.2",
-    "json-parse-safe": "^1.0.3"
+    "json-parse-safe": "^1.0.3",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "istanbul": "^0.4.3",


### PR DESCRIPTION
Creating pull request to add support for adding additional JWT headers to the JWT token.

New headers can be specified in the header property of the payload. For example, to specify a key id (kid) used to sign the JWT token:

``` 
   var jwt = require('json-web-token');
   var payload = { iss: 'my_issurer', iat: 1400062400223, header: {"kid": "myKeyId"} };
   jwt.encode(key, payload, 'RS256');
```

Decoded Header:

```
  {
     "typ": "JWT",
     "alg": "RS256",
     "kid": "myKeyId"
  }
```

Decoded Payload:

```
  {
     "iss": "my_issurer",
     "iat": 1400062400223
  }
```